### PR TITLE
Fixed bug where 'haveCoreMotionPermission' incorrectly returns true

### DIFF
--- a/LocoKit/Base/LocomotionManager.swift
+++ b/LocoKit/Base/LocomotionManager.swift
@@ -762,7 +762,6 @@ import LocoKitCore
                 os_log("error: %@", String(describing: error))
                 
             } else if let motion = motion {
-                self.coreMotionPermission = true
                 ActivityBrain.highlander.add(deviceMotion: motion)
             }
         }


### PR DESCRIPTION
At least on iOS 12.2, 'startDeviceMotionUpdates' provides motion data even while Core Motion permissions are denied. 'startDeviceMotionUpdates' provides valid motion data before and after the permissions alert is denied by the user. It also provides valid motion data if the app is terminated and started again without motion data permissions.

Given this behavior, 'coreMotionPermission' should not be updated to 'true' within the 'startDeviceMotionUpdates' callback.